### PR TITLE
fix: autoCSSModulePlugin can't match camelcase

### DIFF
--- a/src/vitePlugins/autoCSSModule.ts
+++ b/src/vitePlugins/autoCSSModule.ts
@@ -15,7 +15,7 @@ export default function autoCSSModulePlugin(): Plugin {
        * import style from './style.less';
        */
       const REG_EXP =
-        /(import [a-z]+ from ["'].+\.[css|less|sass|scss|styl|stylus]+)(["'])/;
+        /(import [A-Za-z]+ from ["'].+\.[css|less|sass|scss|styl|stylus]+)(["'])/;
 
       if (code.match(REG_EXP)) {
         // The judgment standard of cssModule in vite uses regular matching, add "?module.css" after the path to match successfully, and then cssModule of vite can be used.


### PR DESCRIPTION
#8 
## Test
```javascript
const REG_EXP = /(import [A-Za-z]+ from ["'].+\.[css|less|sass|scss|styl|stylus]+)(["'])/;
`import pageStyles from '@/utils/utils.less';`.match(REG_EXP);
/*
output
["import styles from './index.less'", "import styles from './index.less", "'", index: 0, input: "import styles from './index.less';", groups: undefined]
*/
`import styles from './index.less';`.match(REG_EXP);
/*
output
["import pageStyles from '@/utils/utils.less'", "import pageStyles from '@/utils/utils.less", "'", index: 0, input: "import pageStyles from '@/utils/utils.less';", groups: undefined]
*/
```

## Other
好项目！也许会有前景，是否考虑规范pr，issue流程，让更多的人出一份力？
